### PR TITLE
updated requirements.txt after adding DRF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ Django==1.10.3
 django-forms-bootstrap==3.0.1
 django-gravatar2==1.4.0
 django-storages==1.5.1
+djangorestframework==3.6.3
 gunicorn==19.6.0
+olefile==0.44
 Pillow==4.1.1
 requests==2.12.1
 stripe==1.42.0
-wheel==0.24.0


### PR DESCRIPTION
Just pip installed the missing `djangorestframework`  and recreated the requirements file